### PR TITLE
Add app version to interface

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,6 +4,9 @@ module.exports = {
     browser: true,
     es2021: true,
   },
+  globals: {
+    __APP_VERSION__: 'readonly',
+  },
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ A live demo is available [here](http://tristanpenman.com/demos/n-puzzle).
 
 ## Development
 
-N-Puzzle has been built using [Vue.js](https://vuejs.org/), using Vue [Single File Components](https://vuejs.org/guide/scaling-up/sfc.html).
+N-Puzzle has been built using JavaScript [Vue.js](https://vuejs.org/) framework, using Vue [Single File Components](https://vuejs.org/guide/scaling-up/sfc.html).
 
-The project now uses [Vite](https://vitejs.dev/) for local development and builds.
+The project now uses [Vite](https://vitejs.dev/) for local development and builds. The instructions below assume you are using [pnpm](https://pnpm.io/) package manager.
 
 To run the dev server:
 

--- a/src/js/components/tutorial.vue
+++ b/src/js/components/tutorial.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="Tutorial">
-    <h1>Welcome!</h1>
+    <h1>Welcome! <small class="version">v{{ version }}</small></h1>
     <p>This web application allows you to view a graphical representation of a range of different graph search
       algorithms, whilst solving your choice of 8-puzzle problems.</p>
     <h2>Getting Started</h2>
@@ -142,7 +142,8 @@ export default {
       chooseStateImage,
       stateRepresentationImage,
       astarStepsImage,
-      statsImage
+      statsImage,
+      version: __APP_VERSION__
     };
   }
 };
@@ -166,6 +167,12 @@ export default {
   font-size: 22px;
   margin: 1.2em 0 1em 0;
   padding-bottom: 0.2em;
+}
+
+.Tutorial > h1 > .version {
+  font-size: 13px;
+  font-weight: normal;
+  color: #888;
 }
 
 .Tutorial > h2 {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,15 @@
+import { readFileSync } from 'node:fs';
 import vue from '@vitejs/plugin-vue';
 import { defineConfig } from "vite";
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url)));
 
 export default defineConfig({
   root: "src",
   plugins: [vue()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version)
+  },
   build: {
     outDir: "../dist",
     emptyOutDir: true


### PR DESCRIPTION
Hi @tristanpenman 

Nice seeing you have still been refining this wonderful app.

I am about to start AI again and saw your changes, now it works directly with Node.js, great!

Now, since there are a few versions of this now (the previous was using an simple python based web server), I added the version being run in the interface:

<img width="904" height="315" alt="image" src="https://github.com/user-attachments/assets/00f7ba14-a8e6-4ba0-8b68-b24b67f14c57" />


I am opening this PR in case you are interested. Feel free to ignore or refactor as you wish... 👍🏽 